### PR TITLE
Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM resin/raspberry-pi-alpine-node:6.11.1 AS buildstep
 # and build all node modules
 WORKDIR /usr/src/app
 COPY package.json package.json
-RUN npm install --production
+RUN JOBS=MAX npm install --production --unsafe-perm && npm cache clean && rm -rf /tmp/*
 
 # This is our runtime container that will end up
 # running on the device.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM resin/raspberry-pi-alpine-node:6.11.1 AS buildstep
 # Copy in package.json, install 
 # and build all node modules
 WORKDIR /usr/src/app
-COPY package.json package.json
+COPY package.json .
 RUN JOBS=MAX npm install --production --unsafe-perm && npm cache clean && rm -rf /tmp/*
 
 # This is our runtime container that will end up

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,21 @@
 # This is the base for our build step container
 # which has all our build essentials
-FROM resin/raspberry-pi-alpine-node:6.10 AS buildstep
+FROM resin/raspberry-pi-alpine-node:6.11.1 AS buildstep
 
 # Copy in package.json, install 
 # and build all node modules
-COPY package.json /app/package.json
-WORKDIR /app
-RUN npm i --production
+WORKDIR /usr/src/app
+COPY package.json package.json
+RUN npm install --production
 
 # This is our runtime container that will end up
 # running on the device.
-FROM resin/raspberry-pi-alpine:3.6
+FROM resin/raspberry-pi-alpine-node:6.11.1-slim
 
-RUN apk add --no-cache nodejs
-
-WORKDIR /app
+WORKDIR /usr/src/app
 
 # Copy our node_modules into our deployable container context.
-COPY --from=buildstep /app/node_modules node_modules
+COPY --from=buildstep /usr/src/app/node_modules node_modules
 COPY . .
 
 # Launch our App.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This example uses a "fat" Alpine base image to build all our node.js modules, some of which require additional build tools and make the image pretty big (`434 MB`). We then use [Docker's Multi-stage build feature](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) to copy those built node_modules into a much smaller runtime container which has only the bare essentials that our application needs at runtime.
 
-Our resulting runtime container ends up being just `64.26 MB` (~ 6 times smaller and only about 30MB when compressed and downloaded to the device.) 
+Our resulting runtime container ends up being just `83.7 MB` (~ 5 times smaller and only about 40MB when compressed and downloaded to the device.) 


### PR DESCRIPTION
* change WORKDIR to `/usr/src/app` to be consistent with other projects
* change runtime container to base from `resin/raspberry-pi-alpine-node:6.11.1-slim` so the nodejs versions stay aligned.
* clear npm cache to make the build container a bit smaller to aid pulling in later builds.